### PR TITLE
Require Node.js 8 and update `is-plain-obj` dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
-*.js text eol=lf
+* text=auto eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '12'
+  - '10'
   - '8'
-  - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
 'use strict';
 const isPlainObj = require('is-plain-obj');
 
-module.exports = (obj, opts) => {
+module.exports = (obj, opts = {}) => {
 	if (!isPlainObj(obj)) {
 		throw new TypeError('Expected a plain object');
 	}
 
-	opts = opts || {};
-
-	const deep = opts.deep;
+	const {deep} = opts;
 	const seenInput = [];
 	const seenOutput = [];
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "xo && ava"
@@ -31,7 +31,7 @@
     "recursively"
   ],
   "dependencies": {
-    "is-plain-obj": "^1.0.0"
+    "is-plain-obj": "^2.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Returns a new object with sorted keys.
 
 #### input
 
-Type: `Object`
+Type: `object`
 
 #### options
 
@@ -50,7 +50,7 @@ Recursively sort keys.
 
 ##### compare
 
-Type: `Function`
+Type: `function`
 
 [Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Recursively sort keys.
 
 ##### compare
 
-Type: `function`
+Type: `Function`
 
 [Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 

--- a/test.js
+++ b/test.js
@@ -1,27 +1,27 @@
 import test from 'ava';
-import m from '.';
+import sortKeys from '.';
 
 test('sort the keys of an object', t => {
-	t.deepEqual(m({c: 0, a: 0, b: 0}), {a: 0, b: 0, c: 0});
+	t.deepEqual(sortKeys({c: 0, a: 0, b: 0}), {a: 0, b: 0, c: 0});
 });
 
 test('custom compare function', t => {
 	const compare = (a, b) => a.localeCompare(b);
-	t.deepEqual(m({c: 0, a: 0, b: 0}, {compare}), {c: 0, b: 0, a: 0});
+	t.deepEqual(sortKeys({c: 0, a: 0, b: 0}, {compare}), {c: 0, b: 0, a: 0});
 });
 
 test('deep option', t => {
-	t.deepEqual(m({c: {c: 0, a: 0, b: 0}, a: 0, b: 0}, {deep: true}), {a: 0, b: 0, c: {a: 0, b: 0, c: 0}});
+	t.deepEqual(sortKeys({c: {c: 0, a: 0, b: 0}, a: 0, b: 0}, {deep: true}), {a: 0, b: 0, c: {a: 0, b: 0, c: 0}});
 
 	t.notThrows(() => {
 		const obj = {a: 0};
 		obj.circular = obj;
-		m(obj, {deep: true});
+		sortKeys(obj, {deep: true});
 	});
 
 	const obj = {z: 0};
 	obj.circular = obj;
-	const sortedObj = m(obj, {deep: true});
+	const sortedObj = sortKeys(obj, {deep: true});
 
 	t.is(sortedObj, sortedObj.circular);
 	t.deepEqual(Object.keys(sortedObj), ['circular', 'z']);
@@ -37,19 +37,19 @@ test('deep option', t => {
 	obj4.a[0].c = obj3.a[0];
 
 	t.notThrows(() => {
-		m(obj1, {deep: true});
-		m(obj2, {deep: true});
-		m(obj3, {deep: true});
-		m(obj4, {deep: true});
+		sortKeys(obj1, {deep: true});
+		sortKeys(obj2, {deep: true});
+		sortKeys(obj3, {deep: true});
+		sortKeys(obj4, {deep: true});
 	});
 
-	const sorted = m(obj1, {deep: true});
-	const deepSorted = m(obj3, {deep: true});
+	const sorted = sortKeys(obj1, {deep: true});
+	const deepSorted = sortKeys(obj3, {deep: true});
 
 	t.is(sorted, sorted.a.c);
 	t.deepEqual(deepSorted.a[0], deepSorted.a[0].a.c);
 	t.deepEqual(Object.keys(sorted), ['a', 'b']);
 	t.deepEqual(Object.keys(deepSorted.a[0]), ['a', 'b']);
-	t.deepEqual(m({c: {c: 0, a: 0, b: 0}, a: 0, b: 0, z: [9, 8, 7, 6, 5]}, {deep: true}), {a: 0, b: 0, c: {a: 0, b: 0, c: 0}, z: [9, 8, 7, 6, 5]});
-	t.deepEqual(Object.keys(m({a: [{b: 0, a: 0}]}, {deep: true}).a[0]), ['a', 'b']);
+	t.deepEqual(sortKeys({c: {c: 0, a: 0, b: 0}, a: 0, b: 0, z: [9, 8, 7, 6, 5]}, {deep: true}), {a: 0, b: 0, c: {a: 0, b: 0, c: 0}, z: [9, 8, 7, 6, 5]});
+	t.deepEqual(Object.keys(sortKeys({a: [{b: 0, a: 0}]}, {deep: true}).a[0]), ['a', 'b']);
 });


### PR DESCRIPTION
Additional commit performs the `Meta tweaks` I've seen you do as follow-up on many repos, I hope this is correct / helpful.

Please do not release right away, I have a followup commit to expand handling of `deep: true` for arrays, for example to sort the deep object in `{a: [[{b: 0, a: 0}]]}`.  The additional commit is https://github.com/coreyfarrell/sort-keys/commit/584aa10f4db46e889d9835236e8c21b261831d20, it adds a fair amount of complexity to this module so I figure it'd be better to post a separate PR (if you ask I can add it here).