### PR TITLE
Support sorting of objects inside deep arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,32 @@ module.exports = (object, options = {}) => {
 	const seenInput = [];
 	const seenOutput = [];
 
+	const deepSortArray = array => {
+		const seenIndex = seenInput.indexOf(array);
+
+		if (seenIndex !== -1) {
+			return seenOutput[seenIndex];
+		}
+
+		const result = [];
+		seenInput.push(array);
+		seenOutput.push(result);
+
+		result.push(...array.map(item => {
+			if (Array.isArray(item)) {
+				return deepSortArray(item);
+			}
+
+			if (isPlainObject(item)) {
+				return sortKeys(item);
+			}
+
+			return item;
+		}));
+
+		return result;
+	};
+
 	const sortKeys = object => {
 		const seenIndex = seenInput.indexOf(object);
 
@@ -27,7 +53,7 @@ module.exports = (object, options = {}) => {
 			const value = object[key];
 
 			if (deep && Array.isArray(value)) {
-				result[key] = value.map(arrayValue => isPlainObject(arrayValue) ? sortKeys(arrayValue) : arrayValue);
+				result[key] = deepSortArray(value);
 				continue;
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ sortKeys({c: 0, a: 0, b: 0});
 sortKeys({b: {b: 0, a: 0}, a: 0}, {deep: true});
 //=> {a: 0, b: {a: 0, b: 0}}
 
+sortKeys({b: [{b: 0, a: 0}], a: 0}, {deep: true});
+//=> {a: 0, b: [{a: 0, b: 0}]}
+
 sortKeys({c: 0, a: 0, b: 0}, {
 	compare: (a, b) => -a.localeCompare(b)
 });
@@ -49,7 +52,7 @@ Type: `object`
 Type: `boolean`<br>
 Default: `false`
 
-Recursively sort keys.
+Recursively sort keys, including keys of objects inside arrays.
 
 ##### compare
 

--- a/test.js
+++ b/test.js
@@ -55,21 +55,21 @@ test('deep option', t => {
 });
 
 test('deep arrays', t => {
-	const obj = {
+	const object = {
 		b: 0,
 		a: [
 			{b: 0, a: 0},
 			[{b: 0, a: 0}]
 		]
 	};
-	obj.a.push(obj);
-	obj.a[1].push(obj.a[1]);
+	object.a.push(object);
+	object.a[1].push(object.a[1]);
 
 	t.notThrows(() => {
-		sortKeys(obj, {deep: true});
+		sortKeys(object, {deep: true});
 	});
 
-	const sorted = sortKeys(obj, {deep: true});
+	const sorted = sortKeys(object, {deep: true});
 	t.is(sorted.a[2], sorted);
 	t.is(sorted.a[1][1], sorted.a[1]);
 	t.deepEqual(Object.keys(sorted), ['a', 'b']);

--- a/test.js
+++ b/test.js
@@ -53,3 +53,26 @@ test('deep option', t => {
 	t.deepEqual(sortKeys({c: {c: 0, a: 0, b: 0}, a: 0, b: 0, z: [9, 8, 7, 6, 5]}, {deep: true}), {a: 0, b: 0, c: {a: 0, b: 0, c: 0}, z: [9, 8, 7, 6, 5]});
 	t.deepEqual(Object.keys(sortKeys({a: [{b: 0, a: 0}]}, {deep: true}).a[0]), ['a', 'b']);
 });
+
+test('deep arrays', t => {
+	const obj = {
+		b: 0,
+		a: [
+			{b: 0, a: 0},
+			[{b: 0, a: 0}]
+		]
+	};
+	obj.a.push(obj);
+	obj.a[1].push(obj.a[1]);
+
+	t.notThrows(() => {
+		sortKeys(obj, {deep: true});
+	});
+
+	const sorted = sortKeys(obj, {deep: true});
+	t.is(sorted.a[2], sorted);
+	t.is(sorted.a[1][1], sorted.a[1]);
+	t.deepEqual(Object.keys(sorted), ['a', 'b']);
+	t.deepEqual(Object.keys(sorted.a[0]), ['a', 'b']);
+	t.deepEqual(Object.keys(sorted.a[1][0]), ['a', 'b']);
+});


### PR DESCRIPTION
Still need to update readme.md, want to determine if this is wanted first.  Specifically I'm not sure `sortedKeys([{b: 0, a: 0}], {deep: true})` should be handled or if it should still throw an exception.