### PR TITLE
bind comparator function to object scope

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,11 @@ declare namespace sortKeys {
 
 		/**
 		[Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
+		 @param left - left key
+		 @param right - right key
+		 @param object - the current object whose keys are being compared
 		*/
-		readonly compare?: (left: string, right: string, context?: object) => number;
+		readonly compare?: (left: string, right: string, object?: unknown) => number;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace sortKeys {
 		/**
 		[Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 		*/
-		readonly compare?: (left: string, right: string) => number;
+		readonly compare?: (left: string, right: string, context?: object) => number;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,9 +9,10 @@ declare namespace sortKeys {
 
 		/**
 		[Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
-		 @param left - left key
-		 @param right - right key
-		 @param object - the current object whose keys are being compared
+		
+		@param left - Left key.
+		@param right - Right key.
+		@param object - The current object whose keys are being compared.
 		*/
 		readonly compare?: (left: string, right: string, object?: unknown) => number;
 	}

--- a/index.js
+++ b/index.js
@@ -38,13 +38,14 @@ module.exports = (object, options = {}) => {
 
 	const sortKeys = object => {
 		const seenIndex = seenInput.indexOf(object);
+		const compareFn = options.compare && ((a, b) => options.compare(a, b, object));
 
 		if (seenIndex !== -1) {
 			return seenOutput[seenIndex];
 		}
 
 		const result = {};
-		const keys = Object.keys(object).sort(options.compare && options.compare.bind(object));
+		const keys = Object.keys(object).sort(compareFn);
 
 		seenInput.push(object);
 		seenOutput.push(result);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = (object, options = {}) => {
 		}
 
 		const result = {};
-		const keys = Object.keys(object).sort(options.compare);
+		const keys = Object.keys(object).sort(options.compare && options.compare.bind(object));
 
 		seenInput.push(object);
 		seenOutput.push(result);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sort-keys",
-	"version": "5.0.0",
+	"version": "4.0.0",
 	"description": "Sort the keys of an object",
 	"license": "MIT",
 	"repository": "sindresorhus/sort-keys",
@@ -9,11 +9,7 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
-    "contributors": [{
-      "name": "Moos",
-      "email": "mooster@42at.com"
-    }],
-    "engines": {
+	"engines": {
 		"node": ">=8"
 	},
 	"scripts": {
@@ -41,5 +37,5 @@
 		"ava": "^2.2.0",
 		"tsd": "^0.7.4",
 		"xo": "^0.24.0"
-    }
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sort-keys",
-	"version": "4.0.0",
+	"version": "5.0.0",
 	"description": "Sort the keys of an object",
 	"license": "MIT",
 	"repository": "sindresorhus/sort-keys",
@@ -9,7 +9,11 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
-	"engines": {
+    "contributors": [{
+      "name": "Moos",
+      "email": "mooster@42at.com"
+    }],
+    "engines": {
 		"node": ">=8"
 	},
 	"scripts": {
@@ -37,5 +41,5 @@
 		"ava": "^2.2.0",
 		"tsd": "^0.7.4",
 		"xo": "^0.24.0"
-	}
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,20 @@ sortKeys({c: 0, a: 0, b: 0}, {
 //=> {c: 0, b: 0, a: 0}
 ```
 
+As of v5.x, the comparator function, if given, will be bound to the current object.  It means `this` is available to access the object's values, e.g.:
+
+```js
+sortkeys({{c: 0, a: 0, b: 1}}, {
+  // compare based on keys and values
+  compare: function(left, right) {
+      let lvalue = this[left];
+      let rvalue = this[right];
+      if (lvalue === rvalue) return left.localeCompare(right);
+      return lvalue < rvalue;
+    }
+});
+```
+This can be used, e.g., to group all functions or objects last.  Do not use arrow function here since it would clobber `this`.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -32,21 +32,6 @@ sortKeys({c: 0, a: 0, b: 0}, {
 //=> {c: 0, b: 0, a: 0}
 ```
 
-As of v5.x, the comparator function, if given, will be bound to the current object.  It means `this` is available to access the object's values, e.g.:
-
-```js
-sortkeys({{c: 0, a: 0, b: 1}}, {
-  // compare based on keys and values
-  compare: function(left, right) {
-      let lvalue = this[left];
-      let rvalue = this[right];
-      if (lvalue === rvalue) return left.localeCompare(right);
-      return lvalue < rvalue;
-    }
-});
-```
-This can be used, e.g., to group all functions or objects last.  Do not use arrow function here since it would clobber `this`.
-
 ## API
 
 ### sortKeys(object, options?)
@@ -71,10 +56,11 @@ Recursively sort keys, including keys of objects inside arrays.
 ##### compare
 
 Type: `Function`
+Default: [Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 
-[Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
+If given, the function signature `(a, b, context)` gets a third argument which is the current context, so that the values can be used for comparison as well, as `context[a]` and `context[b]`.
 
-
+ 
 ---
 
 <div align="center">

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ Recursively sort keys, including keys of objects inside arrays.
 Type: `Function`
 Default: [Compare function.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 
-If given, the function signature `(a, b, context)` gets a third argument which is the current context, so that the values can be used for comparison as well, as `context[a]` and `context[b]`.
+If given, the function signature `(a, b, object)` gets a third argument which is the current object, so that the values can be used for comparison as well, as `object[a]` and `object[b]`.
 
  
 ---

--- a/test.js
+++ b/test.js
@@ -6,25 +6,25 @@ const orderedDeepEqual = (t, a, b) => {
 	t.deepEqual(Object.keys(a), Object.keys(b));
 };
 
-const contextCompare = function (a, b, object) {
-	const lvalue = object[a];
-	const rvalue = object[b];
+const contextCompare = (a, b, object) => {
+	const leftValue = object[a];
+	const rightValue = object[b];
 
 	// If values are equal, compare keys
-	if (lvalue === rvalue) {
+	if (leftValue === rightValue) {
 		return a.localeCompare(b);
 	}
 
-	// Else: compare values
-	if (typeof rvalue !== 'number') {
+	// Else, compare values
+	if (typeof rightValue !== 'number') {
 		return -1;
 	}
 
-	if (typeof lvalue !== 'number') {
+	if (typeof leftValue !== 'number') {
 		return 1;
 	}
 
-	return lvalue > rvalue ? 1 : -1;
+	return leftValue > rightValue ? 1 : -1;
 };
 
 test('sort the keys of an object', t => {

--- a/test.js
+++ b/test.js
@@ -6,6 +6,27 @@ const orderedDeepEqual = (t, a, b) => {
 	t.deepEqual(Object.keys(a), Object.keys(b));
 };
 
+const contextCompare = function (a, b, context) {
+	const lvalue = context[a];
+	const rvalue = context[b];
+
+	// If values are equal, compare keys
+	if (lvalue === rvalue) {
+		return a.localeCompare(b);
+	}
+
+	// Else: compare values
+	if (typeof rvalue !== 'number') {
+		return -1;
+	}
+
+	if (typeof lvalue !== 'number') {
+		return 1;
+	}
+
+	return lvalue > rvalue;
+};
+
 test('sort the keys of an object', t => {
 	t.deepEqual(sortKeys({c: 0, a: 0, b: 0}), {a: 0, b: 0, c: 0});
 });
@@ -16,17 +37,15 @@ test('custom compare function', t => {
 });
 
 test('custom compare function with context', t => {
-	const compare = function (a, b) {
-		// If values are equal, compare keys
-		if (this[a] === this[b]) {
-			return a.localeCompare(b);
-		}
+	orderedDeepEqual(t, sortKeys({c: 0, a: 0, b: 1}, {compare: contextCompare}), {a: 0, c: 0, b: 1});
+});
 
-		// Else: compare values
-		return this[a] > this[b];
-	};
-
-	orderedDeepEqual(t, sortKeys({c: 0, a: 0, b: 1}, {compare}), {a: 0, c: 0, b: 1});
+test('custom compare function with context - deep', t => {
+	const orig = {c: 0, a: {f: 2, d: 2, e: 1}, b: 1};
+	const expect = {c: 0, b: 1, a: {e: 1, d: 2, f: 2}};
+	const sorted = sortKeys(orig, {compare: contextCompare, deep: true});
+	orderedDeepEqual(t, sorted, expect);
+	orderedDeepEqual(t, sorted.a, expect.a);
 });
 
 test('deep option', t => {

--- a/test.js
+++ b/test.js
@@ -6,9 +6,9 @@ const orderedDeepEqual = (t, a, b) => {
 	t.deepEqual(Object.keys(a), Object.keys(b));
 };
 
-const contextCompare = function (a, b, context) {
-	const lvalue = context[a];
-	const rvalue = context[b];
+const contextCompare = function (a, b, object) {
+	const lvalue = object[a];
+	const rvalue = object[b];
 
 	// If values are equal, compare keys
 	if (lvalue === rvalue) {

--- a/test.js
+++ b/test.js
@@ -41,9 +41,9 @@ test('custom compare function with context', t => {
 });
 
 test('custom compare function with context - deep', t => {
-	const orig = {c: 0, a: {f: 2, d: 2, e: 1}, b: 1};
+	const fixture = {c: 0, a: {f: 2, d: 2, e: 1}, b: 1};
 	const expect = {c: 0, b: 1, a: {e: 1, d: 2, f: 2}};
-	const sorted = sortKeys(orig, {compare: contextCompare, deep: true});
+	const sorted = sortKeys(fixture, {compare: contextCompare, deep: true});
 	orderedDeepEqual(t, sorted, expect);
 	orderedDeepEqual(t, sorted.a, expect.a);
 });

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ const contextCompare = function (a, b, context) {
 		return 1;
 	}
 
-	return lvalue > rvalue;
+	return lvalue > rvalue ? 1 : -1;
 };
 
 test('sort the keys of an object', t => {


### PR DESCRIPTION
This allows (deep) sorting based on keys **and** values.

Use case: I have an object representation of a deep folder structure.  This change allows doing breadth-first sort.
Source:
```js
{
  c: 'c'
  a: 'a',
  b: { ... },
}
```
Current sorts keys only:
```js
{
  a: 'a',
  b: { ... },
  c: 'c'
}
```
This PR will allow considering the value as well (in this case, nested objects are sorted last)
```js
{
  a: 'a',
  c: 'c',
  b: { ... },
}
```
