### PR TITLE
Add support for top-level arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,4 +43,9 @@ declare function sortKeys<T extends {[key: string]: any}>(
 	options?: sortKeys.Options
 ): T;
 
+declare function sortKeys<T>(
+	object: Array<T>,
+	options?: sortKeys.Options
+): Array<T>;
+
 export = sortKeys;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,9 @@ sortKeys({c: 0, a: 0, b: 0}, {
 	compare: (a, b) => -a.localeCompare(b)
 });
 //=> {c: 0, b: 0, a: 0}
+
+sortKeys([{b: 0, a:2}], {deep: true});
+//=> [{a: 2, b: 0}]
 ```
 */
 declare function sortKeys<T extends {[key: string]: any}>(

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 const isPlainObject = require('is-plain-obj');
 
 module.exports = (object, options = {}) => {
-	if (!isPlainObject(object)) {
-		throw new TypeError('Expected a plain object');
+	if (!isPlainObject(object) && !Array.isArray(object)) {
+		throw new TypeError('Expected a plain object or array');
 	}
 
 	const {deep} = options;
@@ -62,6 +62,10 @@ module.exports = (object, options = {}) => {
 
 		return result;
 	};
+
+	if (Array.isArray(object)) {
+		return deep ? deepSortArray(object) : object.slice();
+	}
 
 	return sortKeys(object);
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,6 +7,9 @@ expectType<{a: 0; b: 0; c: 0}>(sortKeys({c: 0, a: 0, b: 0}));
 expectType<{a: 0; b: {a: 0; b: 0}}>(
 	sortKeys({b: {b: 0, a: 0}, a: 0}, {deep: true})
 );
+expectType<Array<{a: 0; b: 0}>>(
+	sortKeys([{a: 0, b: 0}, {b: 0, a: 0}], {deep: true})
+);
 expectType<{c: 0; b: 0; a: 0}>(
 	sortKeys(
 		{c: 0, a: 0, b: 0},

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Returns a new object with sorted keys.
 
 #### object
 
-Type: `object` | `array`
+Type: `object | Array`
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ sortKeys({c: 0, a: 0, b: 0}, {
 	compare: (a, b) => -a.localeCompare(b)
 });
 //=> {c: 0, b: 0, a: 0}
+
+sortKeys([{b: 0, a:2}], {deep: true});
+//=> [{a: 2, b: 0}]
 ```
 
 
@@ -41,7 +44,7 @@ Returns a new object with sorted keys.
 
 #### object
 
-Type: `object`
+Type: `object` | `array`
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -76,3 +76,18 @@ test('deep arrays', t => {
 	t.deepEqual(Object.keys(sorted.a[0]), ['a', 'b']);
 	t.deepEqual(Object.keys(sorted.a[1][0]), ['a', 'b']);
 });
+
+test('top-level array', t => {
+	const array = [{b: 0, a: 0}, {c: 0, d: 0}];
+	const sorted = sortKeys(array);
+	t.not(sorted, array, 'should make a copy');
+	t.is(sorted[0], array[0]);
+	t.is(sorted[1], array[1]);
+
+	const deepSorted = sortKeys(array, {deep: true});
+	t.not(deepSorted, array);
+	t.not(deepSorted[0], array[0]);
+	t.not(deepSorted[1], array[1]);
+	t.deepEqual(Object.keys(deepSorted[0]), ['a', 'b']);
+	t.deepEqual(Object.keys(deepSorted[1]), ['c', 'd']);
+});


### PR DESCRIPTION
While it's rare you'd want to sort the keys of an Array, this module is used by other libraries that accept objects or arrays (i.e. `hash-obj`). 

Also, the deep option is relevant to arrays. Key order won't change in the top-level Array, but it certainly will in nested objects.

More info: https://github.com/sindresorhus/sort-keys/issues/12#issuecomment-703874787