### PR TITLE
Fix off-by-one `depth` for keys inside array elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,23 +62,24 @@ export default function sortKeys(object, options = {}) {
 			const item = array[index];
 			const indexKey = String(index);
 			const itemPath = buildPath(currentPath, indexKey);
+			const contextDepth = currentDepth + 1;
 			const context = {
 				key: indexKey,
 				value: item,
 				path: itemPath,
-				depth: currentDepth + 1,
+				depth: contextDepth,
 			};
 
 			if (Array.isArray(item)) {
 				result[index] = shouldProcessDeep(context)
-					? deepSortArray(item, itemPath, currentDepth + 1)
+					? deepSortArray(item, itemPath, contextDepth)
 					: item;
 				continue;
 			}
 
 			if (isPlainObject(item)) {
 				result[index] = shouldProcessDeep(context)
-					? _sortKeys(item, itemPath, currentDepth + 1)
+					? _sortKeys(item, itemPath, contextDepth + 1)
 					: item;
 				continue;
 			}

--- a/test.js
+++ b/test.js
@@ -942,4 +942,7 @@ test('depth semantics for arrays and objects in deep function', t => {
 	// Root.arr.0 (array item increases depth)
 	t.truthy(find(['root', 'arr', '0']));
 	t.is(find(['root', 'arr', '0']).depth, 2);
+	// Root.arr.0.y (a key inside an array element is one deeper than the element)
+	t.truthy(find(['root', 'arr', '0', 'y']));
+	t.is(find(['root', 'arr', '0', 'y']).depth, 3);
 });


### PR DESCRIPTION
### What's wrong

`sortKeys` with a depth-limited `deep` function **reorders an object it should have left alone** — anything nested inside an array element is processed one level too early.

Using the exact path the docs document — `index.d.ts` lists `['items', '0', 'title']` as depth `2`:

```js
import sortKeys from 'sort-keys';

const data = {
	items: [
		{title: {start: '2026-01', end: '2026-03'}},
	],
};

// items[0].title is ['items', '0', 'title'] — depth 2 per the docs — so
// `deep: ({depth}) => depth < 2` ("sort down to depth 1") should leave it untouched.
const result = sortKeys(data, {deep: ({depth}) => depth < 2});

result.items[0].title;
//=> {end: '2026-03', start: '2026-01'}   ❌  sorted anyway — "end" now comes before "start"
// expected: {start: '2026-01', end: '2026-03'}
```

`deep: true` / `deep: false` are unaffected (they never use `depth`). The bug only shows with the depth-based function form, and only for objects nested **inside arrays**.

### Why it happens

`depth` should equal the key's nesting level — `path.length - 1` — which `index.d.ts` documents (`['items', '0', 'title']` → `2`). An array element sits at `currentDepth + 1`, so:

- a **nested array** recurses at `currentDepth + 1` — `deepSortArray` adds its own `+ 1` for its elements;
- a **nested object** must recurse at `currentDepth + 2` — its keys are one level deeper than the element, and `_sortKeys` reports keys at exactly the depth it's given.

The bug recursed the object at `currentDepth + 1` (the element's own depth), collapsing the element's keys onto it.

### Fix

Snapshot the element depth once (`contextDepth = currentDepth + 1`) and recurse with `contextDepth` for arrays and `contextDepth + 1` for objects. Reading this local snapshot — rather than `context.depth` — keeps recursion independent of the user's `deep(context)` callback, which is handed the same object and could otherwise mutate `context.depth`. (With the fix, `depth === path.length - 1` holds for every reported path.)

### Tests

Added an assertion that a key inside an array element is one level deeper than the element. Full suite (41 tests) passes, and the new assertion fails without the fix.
